### PR TITLE
Go 1.16.2 and 1.15.10

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,10 +10,10 @@ jobs:
     name: Build Images
     runs-on: ubuntu-latest
     env:
-      LATEST: 1.16
+      LATEST: 1.16.2
     strategy:
       matrix:
-        go-version: [1.16, 1.15.8, 1.14.15]
+        go-version: [1.16.2, 1.15.10]
     steps:
       - uses: actions/checkout@v2
       - name: Login to DockerHub


### PR DESCRIPTION
- Add Go 1.16.2
- Add Go 1.15.10
- Don't build for Go 1.14.x